### PR TITLE
Removes squad color overlays from helmets, armor and gloves [EXPERIMENTAL]

### DIFF
--- a/code/modules/clothing/gloves/marine_gloves.dm
+++ b/code/modules/clothing/gloves/marine_gloves.dm
@@ -21,7 +21,7 @@
 	armor_bio = CLOTHING_ARMOR_MEDIUM
 	armor_rad = CLOTHING_ARMOR_NONE
 	armor_internaldamage = CLOTHING_ARMOR_LOW
-	var/adopts_squad_color = TRUE
+	var/adopts_squad_color = FALSE
 	/// The dmi where the grayscale squad overlays are contained
 	var/squad_overlay_icon = 'icons/mob/humans/onmob/hands_garb.dmi'
 

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -358,7 +358,7 @@ GLOBAL_LIST_INIT(allowed_helmet_items, list(
 	var/helmet_overlays[]
 	flags_inventory = BLOCKSHARPOBJ
 	flags_inv_hide = HIDEEARS
-	var/flags_marine_helmet = HELMET_SQUAD_OVERLAY|HELMET_GARB_OVERLAY|HELMET_DAMAGE_OVERLAY
+	var/flags_marine_helmet = HELMET_GARB_OVERLAY|HELMET_DAMAGE_OVERLAY
 	var/helmet_bash_cooldown = 0
 
 	//speciality does NOTHING if you have NO_NAME_OVERRIDE

--- a/code/modules/clothing/suits/marine_armor.dm
+++ b/code/modules/clothing/suits/marine_armor.dm
@@ -89,7 +89,7 @@
 	var/locate_cooldown = 0 //Cooldown for SL locator
 	var/armor_overlays[]
 	actions_types = list(/datum/action/item_action/toggle)
-	var/flags_marine_armor = ARMOR_SQUAD_OVERLAY|ARMOR_LAMP_OVERLAY
+	var/flags_marine_armor = ARMOR_LAMP_OVERLAY
 	var/specialty = "M3 pattern marine" //Same thing here. Give them a specialty so that they show up correctly in vendors. speciality does NOTHING if you have NO_NAME_OVERRIDE
 	w_class = SIZE_HUGE
 	uniform_restricted = list(/obj/item/clothing/under/marine)


### PR DESCRIPTION
# About the pull request

Squad apparel and armor pieces will no longer reflect squad affiliation.

# Explain why it's good for the game

Squad colors were always offputting and non-realistic. We'll be testing this live for a while to see if it is confusing during gameplay.


# Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<details>
<summary>Screenshots & Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>


# Changelog

:cl:
del: Removes squad affiliation markings from Marine armor pieces.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
