### PR TITLE
Increases the time flares stay on

### DIFF
--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -256,7 +256,7 @@
 
 /obj/item/device/flashlight/flare/Initialize()
 	. = ..()
-	fuel = rand(9.5 MINUTES, 10.5 MINUTES)
+	fuel = rand(15 MINUTES, 20 MINUTES)
 	set_light_color(flame_tint)
 
 /obj/item/device/flashlight/flare/update_icon()
@@ -384,7 +384,7 @@
 
 /obj/item/device/flashlight/flare/on/illumination/Initialize()
 	. = ..()
-	fuel = rand(4.5 MINUTES, 5.5 MINUTES) // Half the duration of a flare, but justified since it's invincible
+	fuel = rand(7.5 MINUTES, 10 MINUTES) // Half the duration of a flare, but justified since it's invincible
 
 /obj/item/device/flashlight/flare/on/illumination/update_icon()
 	return


### PR DESCRIPTION
# About the pull request

Increases flare time considerably, still not near original values.

# Explain why it's good for the game

PR #3677's values are needlessly oppressive, and we'll be strapped for people to watch the LZ as it is. Might be adjusted later.

# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl: Ireul
balance: Mortar flares will last from 7.5 to 10 minutes, while normal flares will last from 15 to 20 minutes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
