### PR TITLE
Unshuffles groundmap vote options

### DIFF
--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -271,7 +271,7 @@ SUBSYSTEM_DEF(vote)
 				choices.Add("Restart Round", "Continue Playing")
 			if("gamemode")
 				question = "Gamemode vote"
-				randomize_entries = TRUE
+				randomize_entries = FALSE
 				for(var/mode_type in config.gamemode_cache)
 					var/datum/game_mode/M = mode_type
 					if(initial(M.config_tag))
@@ -282,7 +282,7 @@ SUBSYSTEM_DEF(vote)
 				question = "Ground map vote"
 				vote_sound = 'sound/voice/start_your_voting.ogg'
 				vote_sound_vol = 15
-				randomize_entries = TRUE
+				randomize_entries = FALSE
 				var/list/maps = list()
 				for(var/i in config.maplist[GROUND_MAP])
 					var/datum/map_config/VM = config.maplist[GROUND_MAP][i]


### PR DESCRIPTION
# About the pull request

as said

# Explain why it's good for the game

Makes it quicker to select the map you want to vote for instead of forcing you to take a look and see where it is

# Changelog

:cl: Ireul
add: Groundmap vote options are now listed in order
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
