### PR TITLE
Makes xenos able to pull dead xenos 

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
+++ b/code/modules/mob/living/carbon/xenomorph/attack_alien.dm
@@ -287,9 +287,6 @@
 	SPAN_DANGER("You nudge your head against [src]."), null, 5, CHAT_TYPE_XENO_FLUFF)
 
 /mob/living/proc/is_xeno_grabbable()
-	if(stat == DEAD)
-		return FALSE
-
 	return TRUE
 
 /mob/living/carbon/human/is_xeno_grabbable()


### PR DESCRIPTION
# About the pull request

as said

# Explain why it's good for the game

There is no reason for xenos not to be able to prevent Marines from gathering more intelligence points through xeno corpses, considering how easy it is to acquire them and how often we see nukes being deployed.

# Changelog

:cl: Ireul
balance: Xeno can pull dead xenos again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
