### PR TITLE
Adds Discord to Hub Display

### DIFF
--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -306,8 +306,8 @@ var/world_topic_spam_protect_time = world.timeofday
 	var/s = ""
 
 	if(CONFIG_GET(string/servername))
-		s += "<a href=\"[CONFIG_GET(string/forumurl)]\"><b>[CONFIG_GET(string/servername)]</b></a>"
-
+		s += "<b>[CONFIG_GET(string/servername)]</b>"
+		s += "<br>Discord: [CONFIG_GET(string/forumurl)]"
 	if(SSmapping?.configs)
 		var/datum/map_config/MG = SSmapping.configs[GROUND_MAP]
 		s += "<br>Map: [MG?.map_name ? "<b>[MG.map_name]</b>" : ""]"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Adds a discord line to the Hub Display, as requested.
# Explain why it's good for the game

So people that don't pay attention to hrefs can actually find our discord.

# Changelog
>

:cl:
add: Added Discord to hub display
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
