### PR TITLE
Comments out ME1 and xeno Young prefix

### DIFF
--- a/code/modules/gear_presets/uscm.dm
+++ b/code/modules/gear_presets/uscm.dm
@@ -78,11 +78,13 @@
 
 	new_human.equip_to_slot_or_del(new back_item(new_human), WEAR_BACK)
 
+/* //Commented while timelocks are off
 /datum/equipment_preset/uscm/pfc/load_rank(mob/living/carbon/human/new_human)
 	if(new_human.client)
 		if(get_job_playtime(new_human.client, rank) < JOB_PLAYTIME_TIER_1)
 			return "ME1"
 	return paygrade
+*/
 
 /datum/equipment_preset/uscm/pfc/cryo
 	name = "USCM Cryo Squad Rifleman"
@@ -467,11 +469,13 @@
 /datum/equipment_preset/uscm/private_equipped/load_status(mob/living/carbon/human/new_human)
 	new_human.nutrition = NUTRITION_NORMAL
 
+/* //Commented while timelocks are off
 /datum/equipment_preset/uscm/private_equipped/load_rank(mob/living/carbon/human/new_human)
 	if(new_human.client)
 		if(get_job_playtime(new_human.client, rank) < JOB_PLAYTIME_TIER_1)
 			return "ME1"
 	return paygrade
+*/
 
 /datum/equipment_preset/uscm/private_equipped/load_gear(mob/living/carbon/human/new_human)
 	new_human.equip_to_slot_or_del(new /obj/item/clothing/under/marine(new_human), WEAR_BODY)

--- a/code/modules/gear_presets/uscm_ship.dm
+++ b/code/modules/gear_presets/uscm_ship.dm
@@ -263,7 +263,7 @@
 	new_human.equip_to_slot_or_del(new /obj/item/storage/bag/trash(new_human), WEAR_L_HAND)
 	new_human.equip_to_slot_or_del(new /obj/item/storage/backpack/marine/engineerpack/welder_chestrig, (new_human), WEAR_R_HAND)
 
-/*		Lowpop CM edit
+/*	//Commented while timelocks are off
 /datum/equipment_preset/uscm_ship/maint/load_rank(mob/living/carbon/human/new_human)
 	if(new_human.client)
 		if(get_job_playtime(new_human.client, rank) < JOB_PLAYTIME_TIER_1)
@@ -388,7 +388,7 @@
 	new_human.equip_to_slot_or_del(new back_item(new_human), WEAR_BACK)
 	new_human.equip_to_slot_or_del(new /obj/item/storage/pouch/general/medium(new_human), WEAR_R_STORE)
 
-/*
+/* //Commented while timelocks are off
 /datum/equipment_preset/uscm_ship/cargo/load_rank(mob/living/carbon/human/new_human)
 	if(new_human.client)
 		if(get_job_playtime(new_human.client, rank) < JOB_PLAYTIME_TIER_1)
@@ -892,8 +892,10 @@
 	new_human.equip_to_slot_or_del(new back_item(new_human), WEAR_BACK)
 	new_human.equip_to_slot_or_del(new /obj/item/storage/pouch/general/medium(new_human), WEAR_R_STORE)
 
+/* //Commented while timelocks are off
 /datum/equipment_preset/uscm_ship/chef/load_rank(mob/living/carbon/human/new_human)
 	if(new_human.client)
 		if(get_job_playtime(new_human.client, rank) < JOB_PLAYTIME_TIER_1)
 			return "ME1"
 	return paygrade
+*/

--- a/code/modules/mob/living/carbon/xenomorph/XenoUpgrade.dm
+++ b/code/modules/mob/living/carbon/xenomorph/XenoUpgrade.dm
@@ -25,7 +25,7 @@
 
 	switch(age)
 		if(XENO_YOUNG)
-			age_prefix = "Young "
+			age_prefix = "" //Null while timelocks are off
 		if(XENO_NORMAL)
 			age_prefix = ""
 		if(XENO_MATURE)


### PR DESCRIPTION
# About the pull request

This PR comments out Marine ME1 (PVT) assignment and 'Young' prefix assignment for new players. Given that everyone will have less than 10 hours in a given role at present, it'll be a bit until these two become relevant.

# Changelog

:cl: Ireul
tweak: Commented ME1 and 'Young' prefix out
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
