### PR TITLE
full volume for all ambience tracks

### DIFF
--- a/code/datums/soundOutput.dm
+++ b/code/datums/soundOutput.dm
@@ -80,7 +80,7 @@
 		ambience = target_ambience
 
 
-	S.volume = 100 * owner.volume_preferences[VOLUME_AMB]
+	S.volume = 100		//You don't get to change it today
 	S.status = status_flags
 
 	if(target_area)


### PR DESCRIPTION
# About the pull request

This makes ambience volume always 100. Really quick tweak, will optimize after the weekend.

# Changelog

:cl:
tweak: Ambience volume is always 100
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
