### PR TITLE
queen abilities tweak

### DIFF
--- a/code/modules/mob/living/carbon/carbon_helpers.dm
+++ b/code/modules/mob/living/carbon/carbon_helpers.dm
@@ -28,17 +28,17 @@
 	if(!(src in mobs_in_view))
 		return
 	var/dist = get_dist(queen, src)
-	if(dist <= 4)
+	if(dist <= 7)
 		to_chat(src, SPAN_DANGER("An ear-splitting guttural roar shakes the ground beneath your feet!"))
-		adjust_effect(4, STUN)
-		apply_effect(4, WEAKEN)
+		/*adjust_effect(4, STUN)
+		apply_effect(4, WEAKEN)*/ //No stun for lowpop
 		if(!ear_deaf || !HAS_TRAIT(src, TRAIT_EAR_PROTECTION))
 			AdjustEarDeafness(5) //Deafens them temporarily
-	else if(dist >= 5 && dist < 7)
-		adjust_effect(3, STUN)
+/*	else if(dist >= 5 && dist < 7)
+		adjust_effect(3, STUN) No stun for lowpop
 		if(!ear_deaf || !HAS_TRAIT(src, TRAIT_EAR_PROTECTION))
 			AdjustEarDeafness(2)
-		to_chat(src, SPAN_DANGER("The roar shakes your body to the core, freezing you in place!"))
+		to_chat(src, SPAN_DANGER("The roar shakes your body to the core, freezing you in place!"))*/
 
 ///Checks if something prevents sharp objects from interacting with the mob (such as armor blocking surgical tools / surgery)
 /mob/living/carbon/proc/get_sharp_obj_blocker(obj/limb/limb)

--- a/code/modules/mob/living/carbon/xenomorph/abilities/queen/queen_abilities.dm
+++ b/code/modules/mob/living/carbon/xenomorph/abilities/queen/queen_abilities.dm
@@ -28,9 +28,23 @@
 	ability_name = "xenomorph heal"
 	plasma_cost = 600
 	macro_path = /datum/action/xeno_action/verb/verb_heal_xeno
-	ability_primacy = XENO_PRIMARY_ACTION_1
 	action_type = XENO_ACTION_CLICK
 	xeno_cooldown = 8 SECONDS
+
+// Queen Fling
+/datum/action/xeno_action/activable/fling/queen
+	name = "Fling"
+	action_icon_state = "fling"
+	ability_name = "Fling"
+	macro_path = /datum/action/xeno_action/verb/verb_fling
+	action_type = XENO_ACTION_CLICK
+	ability_primacy = XENO_PRIMARY_ACTION_1
+	xeno_cooldown = 15 SECONDS
+	// Configurables
+	fling_distance = 4
+	stun_power = 0
+	weaken_power = 0.5
+	slowdown = 8
 
 /datum/action/xeno_action/activable/expand_weeds
 	name = "Expand Weeds (50)"

--- a/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/Queen.dm
@@ -24,7 +24,7 @@
 	evolution_allowed = FALSE
 	fire_immunity = FIRE_IMMUNITY_NO_DAMAGE|FIRE_IMMUNITY_NO_IGNITE
 	caste_desc = "The biggest and baddest xeno. The Queen controls the hive and plants eggs"
-	spit_types = list(/datum/ammo/xeno/toxin/queen, /datum/ammo/xeno/acid/spatter)
+	spit_types = list(/datum/ammo/xeno/toxin, /datum/ammo/xeno/acid/spatter)
 	can_hold_facehuggers = 0
 	can_hold_eggs = CAN_HOLD_ONE_HAND
 	acid_level = 2
@@ -285,6 +285,7 @@
 
 	base_actions = list(
 		/datum/action/xeno_action/onclick/xeno_resting,
+		/datum/action/xeno_action/activable/fling,
 		/datum/action/xeno_action/onclick/regurgitate,
 		/datum/action/xeno_action/watch_xeno,
 		/datum/action/xeno_action/activable/tail_stab,


### PR DESCRIPTION
# About the pull request

Queen neuro becomes base sentinel neuro.
Queen screech now only shakes the screens of everyone in viewrange (might change this to apply buffs to friendlies or debuffs to enemies).
Queen can now fling. 

# Explain why it's good for the game

This is in preparation to definitively nerf the queen or make a new xeno type to replace it. We'll be testing it tonight.

# Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly label your changes in the changelog. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->
<!-- If you add a name after the ':cl', that name will be used in the changelog. You must add your CKEY after the CL if your GitHub name doesn't match. Maintainers freely reserve the right to remove and add tags should they deem it appropriate. -->

:cl:
add: queen can now fling
tweak: screech only shakes everyone's screens (might change this to apply buffs to friendlies or debuffs to enemies)
tweak: queen neuro is now sentinel neuro
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
